### PR TITLE
Added missing repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,5 +285,16 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>sonatype-oss-snapshots</id>
+            <name>Sonatype OSS Maven Repository for Staging Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 </project>


### PR DESCRIPTION
The docking-frames-common artifact moved to Sonatype OSS Maven Repository