### PR TITLE
Iss255 empty attributes

### DIFF
--- a/modules/application/src/main/java/com/sldeditor/datasource/config/DataSourceAttributeModel.java
+++ b/modules/application/src/main/java/com/sldeditor/datasource/config/DataSourceAttributeModel.java
@@ -348,7 +348,7 @@ public class DataSourceAttributeModel extends AbstractTableModel {
         int index = valueMap.size();
         String name = String.format("%s_%d", DEFAULT_NEW_FIELD_NAME, index);
         Class<?> fieldType = DEFAULT_NEW_FIELD_TYPE;
-        Object value = CreateSampleData.getFieldTypeValue(index, name, fieldType);
+        Object value = CreateSampleData.getFieldTypeValue(index, name, fieldType, null);
 
         DataSourceAttributeData newField = new DataSourceAttributeData(name, fieldType, value);
 

--- a/modules/application/src/main/java/com/sldeditor/datasource/impl/CreateSampleData.java
+++ b/modules/application/src/main/java/com/sldeditor/datasource/impl/CreateSampleData.java
@@ -89,8 +89,7 @@ public class CreateSampleData {
 
         // Put fields into map for speed
         Map<String, DataSourceAttributeData> fieldMap = new HashMap<String, DataSourceAttributeData>();
-        if(fieldList != null)
-        {
+        if (fieldList != null) {
             for (DataSourceAttributeData attributeData : fieldList) {
                 fieldMap.put(attributeData.getName(), attributeData);
             }
@@ -121,7 +120,7 @@ public class CreateSampleData {
                 switch (geometryType) {
                 case POLYGON:
                     ExamplePolygonInterface examplePolygon = DataSourceFactory
-                    .createExamplePolygon(null);
+                            .createExamplePolygon(null);
                     value = examplePolygon.getPolygon();
                     break;
                 case LINE:
@@ -143,10 +142,8 @@ public class CreateSampleData {
                     }
                 }
 
-                if (value == null) {
-                    value = getFieldTypeValue(index, attributeType.getName().getLocalPart(),
-                            fieldType);
-                }
+                value = getFieldTypeValue(index, attributeType.getName().getLocalPart(), fieldType,
+                        value);
             }
             builder.add(value);
             index++;
@@ -157,19 +154,35 @@ public class CreateSampleData {
     }
 
     /**
-     * Gets the field type value.
+     * Gets the field type value. If value is set return it, if it is null make up a suitable default
      *
      * @param index the index
-     * @param name the name
+     * @param fieldName the name
      * @param fieldType the field type
+     * @param valueToTest the value to test
      * @return the field type value
      */
-    public static Object getFieldTypeValue(int index, String name, Class<?> fieldType) {
+    public static Object getFieldTypeValue(int index, String fieldName, Class<?> fieldType,
+            Object valueToTest) {
+        if ((valueToTest != null) && (fieldType != String.class)) {
+            return valueToTest;
+        }
+
         Object value = null;
 
         if (fieldType == String.class) {
-            if (name != null) {
-                value = name;
+            if (valueToTest == null) {
+                value = defaultStringValue(fieldName);
+            } else {
+                // Cater for when the string value is empty
+                String s = (String) valueToTest;
+                if (s.trim().isEmpty()) {
+                    value = defaultStringValue(fieldName);
+                }
+                else
+                {
+                    value = valueToTest;
+                }
             }
         } else if (fieldType == Long.class) {
             value = Long.valueOf(index);
@@ -181,6 +194,22 @@ public class CreateSampleData {
             value = Float.valueOf(index);
         } else if (fieldType == Short.class) {
             value = Short.valueOf((short) index);
+        }
+        return value;
+    }
+
+    /**
+     * Default string value.
+     *
+     * @param fieldName the field name
+     * @return the object
+     */
+    private static Object defaultStringValue(String fieldName) {
+        Object value;
+        if (fieldName != null) {
+            value = fieldName;
+        } else {
+            value = "empty";
         }
         return value;
     }

--- a/modules/application/src/main/java/com/sldeditor/datasource/impl/DataSourceImpl.java
+++ b/modules/application/src/main/java/com/sldeditor/datasource/impl/DataSourceImpl.java
@@ -384,15 +384,20 @@ public class DataSourceImpl implements DataSourceInterface {
                     if (name != null) {
                         String fieldName = name.getLocalPart();
 
-                        Class<?> type = fieldTypeMap.get(i);
+                        Class<?> fieldType = fieldTypeMap.get(i);
 
-                        if (type == Geometry.class) {
+                        if (fieldType == Geometry.class) {
                             Object value = feature.getAttribute(fieldName);
 
-                            type = value.getClass();
+                            fieldType = value.getClass();
                         }
-                        DataSourceAttributeData data = new DataSourceAttributeData(fieldName, type,
-                                attributes.get(i));
+
+                        Object value = CreateSampleData.getFieldTypeValue(i, fieldName,
+                                    fieldType,
+                                    attributes.get(i));
+
+                        DataSourceAttributeData data = new DataSourceAttributeData(fieldName, fieldType,
+                                value);
 
                         valueMap.add(data);
                     }

--- a/modules/application/src/main/java/com/sldeditor/ui/attribute/DataSourceAttributePanel.java
+++ b/modules/application/src/main/java/com/sldeditor/ui/attribute/DataSourceAttributePanel.java
@@ -77,14 +77,12 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
     /** The label : data type. */
     private JLabel lblDataType;
 
-
     /**
      * Gets the panel name.
      *
      * @return the panel name
      */
-    public static String getPanelName()
-    {
+    public static String getPanelName() {
         return ATTRIBUTE_PANEL;
     }
 
@@ -106,13 +104,12 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
         attributeComboBox.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
 
-                if(isAttributeComboBoxPopulated())
-                {
+                if (isAttributeComboBoxPopulated()) {
                     String newValueObj = (String) attributeComboBox.getSelectedItem();
-                    UndoManager.getInstance().addUndoEvent(new UndoEvent(thisObj, "DataSourceAttribute", oldValueObj, newValueObj));
+                    UndoManager.getInstance().addUndoEvent(new UndoEvent(thisObj,
+                            "DataSourceAttribute", oldValueObj, newValueObj));
 
-                    if(parentObj != null)
-                    {
+                    if (parentObj != null) {
                         parentObj.updateSymbol();
                     }
                 }
@@ -125,22 +122,18 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      *
      * @param expectedDataType the new data type
      */
-    public void setDataType(Class<?> expectedDataType)
-    {
+    public void setDataType(Class<?> expectedDataType) {
         boolean different = (this.expectedDataType != expectedDataType);
         this.expectedDataType = expectedDataType;
-        
-        if(different)
-        {
-            if(dataSource != null)
-            {
+
+        if (different) {
+            if (dataSource != null) {
                 attributeNameList = this.dataSource.getAttributes(expectedDataType);
                 populateAttributeComboBox();
             }
         }
 
-        if(expectedDataType != null)
-        {
+        if (expectedDataType != null) {
             lblDataType.setText(expectedDataType.getSimpleName().toLowerCase());
         }
     }
@@ -149,22 +142,20 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      * Populate attribute combo box.
      */
     private void populateAttributeComboBox() {
-        if(attributeComboBox != null)
-        {
+        if (attributeComboBox != null) {
             setPopulatingComboBox(true);
             Object selectedItem = model.getSelectedItem();
             model.removeAllElements();
             model.addElement("");
 
-            if(attributeNameList != null)
-            {
-                for(String attribute : attributeNameList)
-                {
+            if (attributeNameList != null) {
+                for (String attribute : attributeNameList) {
                     model.addElement(attribute);
                 }
             }
             attributeComboBox.setModel(model);
             model.setSelectedItem(selectedItem);
+
             setPopulatingComboBox(false);
         }
     }
@@ -192,8 +183,7 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      *
      * @return the selected item
      */
-    public String getSelectedItem()
-    {
+    public String getSelectedItem() {
         return (String) attributeComboBox.getSelectedItem();
     }
 
@@ -205,8 +195,7 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
     public void dataSourceLoaded(DataSourceInterface dataSource) {
         this.dataSource = dataSource;
 
-        if(this.dataSource != null)
-        {
+        if (this.dataSource != null) {
             attributeNameList = this.dataSource.getAttributes(expectedDataType);
         }
 
@@ -218,8 +207,7 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      *
      * @param enabled the new panel enabled
      */
-    public void setPanelEnabled(boolean enabled)
-    {
+    public void setPanelEnabled(boolean enabled) {
         attributeComboBox.setEnabled(enabled);
     }
 
@@ -231,29 +219,22 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
     public void setAttribute(Expression expression) {
         String propertyName = null;
 
-        if(expression instanceof PropertyExistsFunction)
-        {
-            Expression e = ((PropertyExistsFunction)expression).getParameters().get(0);
-            Object value = ((LiteralExpressionImpl)e).getValue();
-            propertyName = ((AttributeExpressionImpl)value).getPropertyName();
-        }
-        else if(expression instanceof AttributeExpressionImpl)
-        {
-            propertyName = ((AttributeExpressionImpl)expression).getPropertyName();
-        }
-        else if(expression instanceof LiteralExpressionImpl)
-        {
-            propertyName = AttributeUtils.extract((String) ((LiteralExpressionImpl)expression).getValue());
+        if (expression instanceof PropertyExistsFunction) {
+            Expression e = ((PropertyExistsFunction) expression).getParameters().get(0);
+            Object value = ((LiteralExpressionImpl) e).getValue();
+            propertyName = ((AttributeExpressionImpl) value).getPropertyName();
+        } else if (expression instanceof AttributeExpressionImpl) {
+            propertyName = ((AttributeExpressionImpl) expression).getPropertyName();
+        } else if (expression instanceof LiteralExpressionImpl) {
+            propertyName = AttributeUtils
+                    .extract((String) ((LiteralExpressionImpl) expression).getValue());
         }
 
-        if(propertyName != null)
-        {
+        if (propertyName != null) {
             oldValueObj = propertyName;
 
             attributeComboBox.setSelectedItem(propertyName);
-        }
-        else
-        {
+        } else {
             oldValueObj = propertyName;
             attributeComboBox.setSelectedIndex(-1);
         }
@@ -265,9 +246,13 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      * @return the expression
      */
     public Expression getExpression() {
-        String attributeName = (String)attributeComboBox.getSelectedItem();
-        NameImpl name = new NameImpl(attributeName);
-        Expression expression = new AttributeExpressionImpl(name);
+        Expression expression = null;
+        String attributeName = (String) attributeComboBox.getSelectedItem();
+
+        if (attributeName != null) {
+            NameImpl name = new NameImpl(attributeName);
+            expression = new AttributeExpressionImpl(name);
+        }
 
         return expression;
     }
@@ -277,12 +262,14 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      *
      * @param undoRedoObject the undo redo object
      */
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see com.sldeditor.undo.UndoActionInterface#undoAction(com.sldeditor.undo.UndoInterface)
      */
     @Override
     public void undoAction(UndoInterface undoRedoObject) {
-        String oldValueObj = (String)undoRedoObject.getOldValue();
+        String oldValueObj = (String) undoRedoObject.getOldValue();
 
         attributeComboBox.setSelectedItem(oldValueObj);
     }
@@ -292,12 +279,14 @@ public class DataSourceAttributePanel extends JPanel implements UndoActionInterf
      *
      * @param undoRedoObject the undo redo object
      */
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
+     * 
      * @see com.sldeditor.undo.UndoActionInterface#redoAction(com.sldeditor.undo.UndoInterface)
      */
     @Override
     public void redoAction(UndoInterface undoRedoObject) {
-        String newValueObj = (String)undoRedoObject.getNewValue();
+        String newValueObj = (String) undoRedoObject.getNewValue();
 
         attributeComboBox.setSelectedItem(newValueObj);
     }

--- a/modules/application/src/test/java/com/sldeditor/test/unit/datasource/impl/CreateSampleDataTest.java
+++ b/modules/application/src/test/java/com/sldeditor/test/unit/datasource/impl/CreateSampleDataTest.java
@@ -67,6 +67,7 @@ public class CreateSampleDataTest {
         // Build the feature type
         SimpleFeatureType schema = b.buildFeatureType();
 
+        sampleData.create(null, null);
         sampleData.create(schema, null);
 
         DataStore dataStore = sampleData.getDataStore();
@@ -80,14 +81,19 @@ public class CreateSampleDataTest {
      */
     @Test
     public void testGetFieldTypeValue() {
-        String expectedString = "String field";
-        assertEquals(expectedString, CreateSampleData.getFieldTypeValue(0, expectedString, String.class));
-        assertEquals(Long.valueOf(1), CreateSampleData.getFieldTypeValue(1, expectedString, Long.class));
-        assertEquals(Short.valueOf((short)2), CreateSampleData.getFieldTypeValue(2, expectedString, Short.class));
-        assertEquals(Integer.valueOf(3), CreateSampleData.getFieldTypeValue(3, expectedString, Integer.class));
-        assertEquals(Float.valueOf(4), CreateSampleData.getFieldTypeValue(4, expectedString, Float.class));
-        assertEquals(Double.valueOf(5), CreateSampleData.getFieldTypeValue(5, expectedString, Double.class));
-        assertNull(CreateSampleData.getFieldTypeValue(6, expectedString, SimpleFeatureType.class));
+        String expectedFieldName = "String field";
+        assertEquals(expectedFieldName, CreateSampleData.getFieldTypeValue(0, expectedFieldName, String.class, null));
+        assertEquals(Long.valueOf(1), CreateSampleData.getFieldTypeValue(1, expectedFieldName, Long.class, null));
+        assertEquals(Short.valueOf((short)2), CreateSampleData.getFieldTypeValue(2, expectedFieldName, Short.class, null));
+        assertEquals(Integer.valueOf(3), CreateSampleData.getFieldTypeValue(3, expectedFieldName, Integer.class, null));
+        assertEquals(Float.valueOf(4), CreateSampleData.getFieldTypeValue(4, expectedFieldName, Float.class, null));
+        assertEquals(Double.valueOf(5), CreateSampleData.getFieldTypeValue(5, expectedFieldName, Double.class, null));
+        assertNull(CreateSampleData.getFieldTypeValue(6, expectedFieldName, SimpleFeatureType.class, null));
+
+        String expectedStringValue = "test";
+        assertEquals(expectedStringValue, CreateSampleData.getFieldTypeValue(0, expectedFieldName, String.class, expectedStringValue));
+        assertEquals(expectedFieldName, CreateSampleData.getFieldTypeValue(0, expectedFieldName, String.class, ""));
+        assertEquals("empty", CreateSampleData.getFieldTypeValue(0, null, String.class, ""));
     }
 
 }


### PR DESCRIPTION
Where attribute name is null return a null expression, this prevents issues when rendering and it can't find a 'null' field in the data source.
Added code so that empty strings have a default value in data sources.